### PR TITLE
Add `qt6.qtserialport` to `flake.nix`.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
         buildInputs = (with pkgs; [
           qt6.qtbase
           qt6.qtmultimedia
+          qt6.qtserialport
           SDL2
           zstd
           libarchive


### PR DESCRIPTION
Just a tiny update to add the new QT6 library required to `flake.nix`.